### PR TITLE
Fix map marker creation inside for loops

### DIFF
--- a/lib/jekyll-leaflet/leaflet-items/leaflet-marker.rb
+++ b/lib/jekyll-leaflet/leaflet-items/leaflet-marker.rb
@@ -14,10 +14,10 @@ module Jekyll
         end
 
         def render(context)
-            @input = parse_liquid_output_in(@input, context)
+            value = parse_liquid_output_in(@input, context)
             '{id: "' + SecureRandom.hex + '",
               type: "LeafletMarker",
-              value: ' + @input + '},'
+              value: ' + value + '},'
         end
     end
 end


### PR DESCRIPTION
@fchavat 's fix for map markers being created inside for loops. Fixes #2.

## QA Checklist

- [X] Did you serve the site at `./docs` and assert that any changes don't break exist functionality? Your locally served site should match the documentation located at https://davidjvitale.com/tech/jekyll-leaflet/.
- [X] If implementing a new feature, did you add a new section in the `./docs/` site?

